### PR TITLE
Add support for Compiz Boxmenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,4 +206,44 @@ updated. The upside is that the menu will not be generated every time
 you access the menu. This might be a better choice for (really) older
 hardware.
 
+Compiz Boxmenu
+==============
+There are two ways to have an xdg menu in compiz-boxmenu. The first one,
+auto-updates the menu, every time the menu is called. The second one,
+updates the menu only when the user wants to.
+
+Also, keep in mind that Compiz Boxmenu supports multiple formats. Thus
+
+Dynamic Menus
+-------------
+Edit your `~/.config/compiz/boxmenu/menu.xml` file with your favorite text 
+editor and add a block of code like this inside the root `<menu>` element:
+
+~~~
+<item type="launcher">
+	<command mode2="pipe">xdgmenumaker -nif compizboxmenu</command>
+	<icon>applications</icon>
+	<name>Applications</name>
+</item>
+~~~
+
+Alternatively, you can also run `compiz-boxmenu-editor` and click the 
+dropdown for new menu files or menu items. Select launcher to create a 
+new launcher. Set the name of the launcher to whatever you want. This will
+be the display name for the pipe menu. Then enter in
+`xdgmenumaker -nif compizboxmenu` for the command entry. Click the combobox
+next to the command text box and switch that to "Pipe".
+
+
+Static Menus
+------------
+Edit your `~/.config/compiz/boxmenu/menu.xml` file with your favorite text 
+editor and paste the output of `xdgmenumaker -if compizboxmenu` into
+`~/.config/compiz/boxmenu/menu.xml`.
+
+Alternatively, you can also run `compiz-boxmenu-editor` and click the
+button that says `Generate menu entries from a pipemenu script`. In the dialog
+box that pops up, type in `xdgmenumaker -if compizboxmenu` or 
+`xdgmenumaker -nif compizboxmenu` to append the statically generated
+menu to any menu file you want.
 

--- a/src/xdgmenumaker
+++ b/src/xdgmenumaker
@@ -188,6 +188,8 @@ def main(argv):
         pekwmmenu()
     elif desktop == "jwm":
         jwmmenu()
+    elif desktop == "compizboxmenu":
+        compizboxmenu()
     else:
         usage()
         sys.exit(2)
@@ -235,7 +237,7 @@ def icon_full_path(icon):
         return icon
 
 
-def get_entry_info(desktopfile):
+def get_entry_info(desktopfile, ico_paths=True):
     de = dentry.DesktopEntry(filename=desktopfile)
 
     # skip processing the rest of the desktop entry if the item is to not be
@@ -257,7 +259,8 @@ def get_entry_info(desktopfile):
     if seticon:
         # strip the directory and extension from the icon name
         icon = de.getIcon()
-        icon = icon_full_path(icon)
+        if ico_paths:
+            icon = icon_full_path(icon)
     else:
         icon = None
 
@@ -349,11 +352,11 @@ def desktopfilelist():
     return filelist
 
 
-def menu():
+def menu(ico_paths=True):
     applist = []
     for desktopfile in desktopfilelist():
         try:
-            entry = get_entry_info(desktopfile)
+            entry = get_entry_info(desktopfile, ico_paths=ico_paths)
             if entry is not None:
                 applist.append(entry)
         except exc.ParsingError:
@@ -592,6 +595,48 @@ def jwmmenu():
     if submenu:
         print('</Menu>')
     print('</JWM>')
+
+def compizboxmenu():
+    if submenu:
+        spacing = '\t'
+        if seticon:
+            app_icon = icon_full_path(applications_icon)
+            if app_icon is None:
+                print('<menu name="' + applications + '">')
+            else:
+                print('<menu icon="' + app_icon +
+                      '" name="' + applications + '">')
+        else:
+            print('<menu name="' + applications + '">')
+    else:
+        spacing = ''
+    for menu_category in menu(ico_paths=False):
+        category = menu_category.category
+        cat_icon = category_icon(category)
+        if seticon and cat_icon is not None:
+            print(spacing + '<menu icon="' + cat_icon +
+                  '" name="' + category + '">')
+        else:
+            print(spacing + '<menu name="' + category + '">')
+        for app in menu_category.applist:
+            name = app.name
+            icon = app.icon
+            command = app.command
+            path = app.path
+            if path is not None:
+                command = 'sh -c \'cd "' + path.replace("'", "'\\''") + '" ; ' + command.replace("'", "'\\''") + '\''
+            if seticon and icon is not None:
+                print(('{}<item type="launcher"><name>{}</name>'
+                            '<icon>{}</icon>'
+                            '<command>{}</command></item>').format(spacing,
+                            name, icon, command))
+            else:
+                print(('{}<item type="launcher"><name>{}</name>'
+                            '<command>{}</command></item>').format(spacing,
+                            name, command))
+        print(spacing + '</menu>')
+    if submenu:
+        print('</menu>')
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/src/xdgmenumaker
+++ b/src/xdgmenumaker
@@ -26,7 +26,7 @@ pekwmdynamic = False
 # for them, where they should be if this was installed properly
 prefix = 'not_set'
 if prefix == 'not_set':
-    desktop_dir = '../desktop-directories/'
+    desktop_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'desktop-directories/')
 else:
     desktop_dir = prefix + '/share/desktop-directories/'
 
@@ -619,7 +619,7 @@ def compizboxmenu():
         else:
             print(spacing + '<menu name="' + category + '">')
         for app in menu_category.applist:
-            name = app.name
+            name = app.name.replace('&', '&amp;')
             icon = app.icon
             command = app.command
             path = app.path
@@ -629,11 +629,11 @@ def compizboxmenu():
                 print(('{}<item type="launcher"><name>{}</name>'
                             '<icon>{}</icon>'
                             '<command>{}</command></item>').format(spacing,
-                            name, icon, command))
+                            name, icon, command.replace('&', '&amp;')))
             else:
                 print(('{}<item type="launcher"><name>{}</name>'
                             '<command>{}</command></item>').format(spacing,
-                            name, command))
+                            name, command.replace('&', '&amp;')))
         print(spacing + '</menu>')
     if submenu:
         print('</menu>')


### PR DESCRIPTION
This adds support for Compiz-Boxmenu. File paths aren't retrieved for the icons since Compiz-Boxmenu supports using GTK+ icon themes natively.