### PR TITLE
handle OnlyShowIn and NotShowIn better

### DIFF
--- a/src/xdgmenumaker
+++ b/src/xdgmenumaker
@@ -400,11 +400,11 @@ def get_entry_info(desktopfile, ico_paths=True):
     hidden = de.getHidden()
     nodisplay = de.getNoDisplay()
     # none of the freedesktop registered environments are supported by
-    # OnlyShowIn anyway:
+    # OnlyShowIn but it might be worth using some extra logic here.
     # http://standards.freedesktop.org/menu-spec/latest/apb.html
-    # So if OnlyShowIn is set, it certainly isn't for any of the WMs
-    # xdgmenumaker supports.
-    if (onlyshowin != []) or (desktop in notshowin) or hidden or nodisplay:
+    if (onlyshowin != [] and not (desktop.lower() in (name.lower() for name in onlyshowin))) \
+        or (desktop.lower() in (name.lower for name in notshowin)) \
+        or hidden or nodisplay:
         return None
 
     name = de.getName().encode('utf-8')


### PR DESCRIPTION
While the target WMs are not registered with freedesktop, some users do use these fields for these WMs.
https://github.com/search?l=&q=onlyshowin%3D.%2Afluxbox+extension%3Adesktop&type=Code returns 367 code results.

This merge request differs from #10 by using the provided "-f desktopname" parameter instead of reading the current environment from XDG variables. The -f parameter is required and is the canonical target WM for the run of the program.