### PR TITLE
Drop support for Python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ xdgmenumaker currently supports generating menus for:
 * windowmaker
 
 **xdgmenumaker** requires:
-* Python 2.7 or 3.x
+* Python 3.x
 * pyxdg
-* pygtk (for Python 2)
-* pygobject and gobject-instrospection (for Python 3)
+* pygobject and gobject-instrospection
 * Pillow (optional)
 
 

--- a/man/xdgmenumaker.t2t
+++ b/man/xdgmenumaker.t2t
@@ -40,9 +40,8 @@ according to the running user locale settings.
 - windowmaker
 
 
-**xdgmenumaker** requires //Python 2.7// or //3.x//, //pygtk//
-(for Python 2.7) or //pygobject// and //gobject-instrospection//
-(for Python 3.x), as well as //pyxdg//. //Pillow// is an optional
+**xdgmenumaker** requires //Python 3.x//, //pygobject// and
+//gobject-instrospection//, as well as //pyxdg//. //Pillow// is an optional
 dependency (used by the **--max-icon-size** option).
 
 

--- a/src/xdgmenumaker
+++ b/src/xdgmenumaker
@@ -13,21 +13,12 @@ import xdg.Exceptions as exc
 import xdg.BaseDirectory as bd
 from operator import attrgetter
 
-# ConfigParser in Python2 has been renamed to configparser (all lower case)
-# in Python3. So, it's a good way to find out which Python version is being
-# used.
-python3 = False
-try:
-    import ConfigParser as cp
-except ImportError:
-    import configparser as cp
-    python3 = True
+import configparser as cp
 
-# Under Python3, load the gtk compatibility layer
-if python3:
-    from gi import pygtkcompat
-    pygtkcompat.enable()
-    pygtkcompat.enable_gtk(version='3.0')
+# Load the gtk compatibility layer
+from gi import pygtkcompat
+pygtkcompat.enable()
+pygtkcompat.enable_gtk(version='3.0')
 import gtk
 
 seticon = False

--- a/src/xdgmenumaker
+++ b/src/xdgmenumaker
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 # vim:et:sta:sts=4:sw=4:ts=8:tw=79:
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 MM ?= ../src/xdgmenumaker
-PYTHON ?= python
+PYTHON ?= python3
 
 test: clean generate
 	@for i in `ls menus_correct/`; do \


### PR DESCRIPTION
Python 2 went EOL almost 1 year and half ago, and Python 2 bits are tested less and less. Even more, Python 3 has been available for years before that.

Hence, drop the support for Python 2, and assume Python 3 instead. This series does the minimal work to drop Python 2 support, without looking further into Python 2-isms.