### PR TITLE
Switch to PyXDG.IconTheme for icons lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ xdgmenumaker currently supports generating menus for:
 **xdgmenumaker** requires:
 * Python 3.x
 * pyxdg
-* pygobject and gobject-instrospection
 * Pillow (optional)
 
 

--- a/man/xdgmenumaker.t2t
+++ b/man/xdgmenumaker.t2t
@@ -40,9 +40,8 @@ according to the running user locale settings.
 - windowmaker
 
 
-**xdgmenumaker** requires //Python 3.x//, //pygobject// and
-//gobject-instrospection//, as well as //pyxdg//. //Pillow// is an optional
-dependency (used by the **--max-icon-size** option).
+**xdgmenumaker** requires //Python 3.x//, as well as //pyxdg//.
+//Pillow// is an optional dependency (used by the **--max-icon-size** option).
 
 
 = OPTIONS =

--- a/src/xdgmenumaker
+++ b/src/xdgmenumaker
@@ -9,6 +9,7 @@ import fnmatch
 import xdg.DesktopEntry as dentry
 import xdg.Exceptions as exc
 import xdg.BaseDirectory as bd
+import xdg.IconTheme as it
 from operator import attrgetter
 
 import configparser as cp
@@ -289,37 +290,25 @@ def icon_max_size(icon):
 
 
 def icon_full_path(icon):
-    # If the icon path is absolute and exists, leave it alone.
-    # This takes care of software that has its own icons stored
-    # in non-standard directories.
-    ext = os.path.splitext(icon)[1].lower()
-    if os.path.exists(icon):
-        if ext == ".svg" or ext == ".svgz":
-            # only jwm supports svg icons
-            if desktop == "jwm" and not nosvg:
-                return icon
-        else:
-            # icon is not svg
-            if max_icon_size:
-                return icon_max_size(icon)
-            else:
-                return icon
-    # fall back to looking for the icon elsewhere in the system
-    icon = icon_strip(icon)
-    icon_theme = gtk.icon_theme_get_default()
-    try:
-        # JWM supports svg icons
-        if desktop == "jwm" and not nosvg:
-            icon = icon_theme.lookup_icon(icon, iconsize, gtk.ICON_LOOKUP_FORCE_SVG)
-        # but none of the other WMs does
-        else:
-            icon = icon_theme.lookup_icon(icon, iconsize, gtk.ICON_LOOKUP_NO_SVG)
-    except AttributeError:
-        sys.exit('ERROR: You need to run xdgmenumaker inside an X session.')
+    args = {
+        'size': iconsize,
+        'theme': 'hicolor'
+    }
+    lookup_svg = True
+    if not desktop == "jwm" or nosvg:
+        lookup_svg = False
+    if not lookup_svg:
+        args['extensions'] = ["png", "xpm"]
+    icon = it.getIconPath(icon, **args)
     if icon:
-        icon = icon.get_filename()
+        ext = os.path.splitext(icon)[1]
+        is_svg = ext == ".svg" or ext == ".svgz"
+        # SVG returned but not requested, most probably is an absolute path:
+        # ignore it, as it is not usable
+        if is_svg and not lookup_svg:
+            icon = None
         # icon size only matters for non-SVG icons
-        if icon and max_icon_size and (ext != ".svg" or ext != ".svgz"):
+        elif max_icon_size and not is_svg:
             icon = icon_max_size(icon)
     return icon
 

--- a/src/xdgmenumaker
+++ b/src/xdgmenumaker
@@ -14,11 +14,6 @@ from operator import attrgetter
 
 import configparser as cp
 
-# Load the gtk compatibility layer
-from gi import pygtkcompat
-pygtkcompat.enable()
-pygtkcompat.enable_gtk(version='3.0')
-import gtk
 
 seticon = False
 iconsize = 16

--- a/src/xdgmenumaker
+++ b/src/xdgmenumaker
@@ -28,6 +28,7 @@ submenu = True
 pekwmdynamic = False
 twmtitles = False
 max_icon_size = False
+icontheme = 'hicolor'
 
 # the following line gets changed by the Makefile. If it is set to
 # 'not_set' it looks in the currect directory tree for the .directory
@@ -163,6 +164,7 @@ def main(argv):
     global pekwmdynamic
     global twmtitles
     global max_icon_size
+    global icontheme
     try:
         opts, args = getopt.getopt(argv, "hins:f:", ["help", "icons",
                                                      "no-submenu",
@@ -171,7 +173,8 @@ def main(argv):
                                                      "max-icon-size",
                                                      "no-svg",
                                                      "size=",
-                                                     "format="])
+                                                     "format=",
+                                                     "icon-theme="])
     except getopt.GetoptError:
         usage()
         sys.exit(2)
@@ -211,6 +214,8 @@ def main(argv):
             nosvg = True
         elif opt in ("-f", "--format"):
             desktop = arg
+        elif opt == "--icon-theme":
+            icontheme = arg
     if not desktop:
         usage()
         sys.exit('ERROR: You must specify the output format with -f')
@@ -257,6 +262,7 @@ def usage():
     print('        --max-icon-size  restrict the icon sizes to the specified size')
     print('        --pekwm-dynamic  generate dynamic menus for pekwm')
     print('        --twm-titles     show menu titles in twm menus')
+    print('        --icon-theme     XDG icon theme to lookup icons in (default: hicolor)')
     print('    -h, --help           show this help message')
     print('  You have to specify the output format using the -f switch.')
     print()
@@ -292,7 +298,7 @@ def icon_max_size(icon):
 def icon_full_path(icon):
     args = {
         'size': iconsize,
-        'theme': 'hicolor'
+        'theme': icontheme
     }
     lookup_svg = True
     if not desktop == "jwm" or nosvg:


### PR DESCRIPTION
Use PyXDG.IconTheme to lookup the application icons instead of pyGTK; this has some advantages:
- we are already using PyXDG, so it does not add new requirements
- the icon lookup follows the icon theme specs a little bit closer
- the icon lookup does not require an X/graphical session
- there is no implicit `adwaita` or `gnome` icon theme used in lookup

there are also few disadvantages:
- there is no concept of "default icon theme", so `hicolor` is the default theme; a new `--icon-theme` option is added to select which theme to use
- it seems the lookup logic for hicolor returns the smallest icon available in case the current size is not available: for example a 16px PNG is returned instead of a 48px for a requested and not found 64px size
